### PR TITLE
[NVSHAS-8938] Add Critical CVE Severity to support CVSS v3 scores 9.0-10.0 (CI/CD tool)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,19 @@
         </plugins>
     </build>
 
+<pluginRepositories>
+    <pluginRepository>
+        <id>atlassian-public</id>
+        <url>https://m2proxy.atlassian.com/repository/public/</url>
+        <releases>
+            <enabled>true</enabled>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </pluginRepository>
+</pluginRepositories>
+
 <repositories>
     <repository>
         <id>atlassian-public</id>
@@ -175,5 +188,4 @@
         </snapshots>
     </repository>
 </repositories>
-
 </project>

--- a/src/main/java/neuvector/NeuVectorGlobalConfigurator.java
+++ b/src/main/java/neuvector/NeuVectorGlobalConfigurator.java
@@ -4,6 +4,7 @@ import com.atlassian.bamboo.configuration.AdministrationConfiguration;
 import com.atlassian.bamboo.configuration.AdministrationConfigurationPersister;
 import com.atlassian.bamboo.configuration.GlobalAdminAction;
 import com.atlassian.spring.container.ContainerManager;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import java.net.InetAddress;
 
@@ -19,6 +20,11 @@ public class NeuVectorGlobalConfigurator extends GlobalAdminAction {
     private String scannerImageRepository;
     private String scannerRegistryUsername;
     private String scannerRegistryPassword;
+    
+    private boolean isCustomThreshold = false;
+    private String customCriticalThreshold;
+    private String customHighThreshold;
+    private String customMediumThreshold;
 
     public String execute() throws Exception {
         final AdministrationConfiguration adminConfig = (AdministrationConfiguration) ContainerManager.getComponent("administrationConfiguration");
@@ -33,11 +39,20 @@ public class NeuVectorGlobalConfigurator extends GlobalAdminAction {
         this.scannerImageRepository = adminConfig.getSystemProperty("scannerImageRepository");
         this.scannerRegistryUsername = adminConfig.getSystemProperty("scannerRegistryUsername");
         this.scannerRegistryPassword = adminConfig.getSystemProperty("scannerRegistryPassword");
+
+        this.customCriticalThreshold = adminConfig.getSystemProperty("customCriticalThreshold");
+        this.customHighThreshold = adminConfig.getSystemProperty("customHighThreshold");
+        this.customMediumThreshold = adminConfig.getSystemProperty("customMediumThreshold");
+
         return "input";
     }
 
     public String save() {
         final AdministrationConfiguration adminConfig = (AdministrationConfiguration) ContainerManager.getComponent("administrationConfiguration");
+        if (!checkCustomThreshold(this.customCriticalThreshold, this.customHighThreshold, this.customMediumThreshold)) {
+            return "success";
+        }
+
         adminConfig.setSystemProperty("controllerIP", this.controllerIP);
         adminConfig.setSystemProperty("controllerPort", this.controllerPort);
         adminConfig.setSystemProperty("nvUsername", this.nvUsername);
@@ -50,6 +65,12 @@ public class NeuVectorGlobalConfigurator extends GlobalAdminAction {
         adminConfig.setSystemProperty("scannerRegistryUsername", this.scannerRegistryUsername);
         adminConfig.setSystemProperty("scannerRegistryPassword", this.scannerRegistryPassword);
 
+        adminConfig.setSystemProperty("customCriticalThreshold", this.customCriticalThreshold);
+        adminConfig.setSystemProperty("customHighThreshold", this.customHighThreshold);
+        adminConfig.setSystemProperty("customMediumThreshold", this.customMediumThreshold);
+        adminConfig.setSystemProperty("customMediumThreshold", this.customMediumThreshold);
+        adminConfig.setSystemProperty("isCustomThreshold", String.valueOf(this.isCustomThreshold));
+        
         ((AdministrationConfigurationPersister) ContainerManager.getComponent("administrationConfigurationPersister")).saveAdministrationConfiguration(adminConfig);
         this.addActionMessage("NeuVector Global Configuration Successfully Saved");
         return "success";
@@ -76,6 +97,41 @@ public class NeuVectorGlobalConfigurator extends GlobalAdminAction {
             this.addActionError("Please enter a number for Controller Port");
             return false;
         }
+    }
+
+    public boolean checkCustomThreshold(final String customCriticalThreshold, final String customHighThreshold, final String customMediumThreshold) {
+        if (customCriticalThreshold == null && customHighThreshold == null && customMediumThreshold == null) {
+            return true;
+        }
+
+        if (!NumberUtils.isParsable(customCriticalThreshold) || !NumberUtils.isParsable(customHighThreshold) || !NumberUtils.isParsable(customMediumThreshold)) {
+            this.addActionError("One or more thresholds are not valid numbers.");
+            return false;
+        }
+    
+        try {
+            double criticalSeverityThreshold = Double.parseDouble(customCriticalThreshold.trim());
+            double highSeverityThreshold = Double.parseDouble(customHighThreshold.trim());
+            double mediumSeverityThreshold = Double.parseDouble(customMediumThreshold.trim());
+            
+            if (criticalSeverityThreshold < 0.0 || criticalSeverityThreshold > 10.0 ||
+                highSeverityThreshold < 0.0 || highSeverityThreshold > 10.0 ||
+                mediumSeverityThreshold < 0.0 || mediumSeverityThreshold > 10.0) {
+                this.addActionError("Threshold values must be between 0.0 and 10.0.");
+                return false;
+            }
+    
+            if (criticalSeverityThreshold <= highSeverityThreshold || criticalSeverityThreshold <= mediumSeverityThreshold || highSeverityThreshold <= mediumSeverityThreshold) {
+                this.addActionError("Thresholds must satisfy: Critical > High > Medium.");
+                return false;
+            }
+
+        } catch (NumberFormatException e) {
+            this.addActionError("An unexpected error occurred while parsing the numbers."); // Fallback error
+            return false;
+        } 
+        isCustomThreshold = true;  
+        return true;
     }
 
     public String getControllerIP() {
@@ -165,4 +221,36 @@ public class NeuVectorGlobalConfigurator extends GlobalAdminAction {
     public void setScannerRegistryPassword(String scannerRegistryPassword) {
         this.scannerRegistryPassword = scannerRegistryPassword;
     } 
+
+    public String getCustomCriticalThreshold() {
+        return customCriticalThreshold;
+    }
+
+    public void setCustomCriticalThreshold(String customCriticalThreshold) {
+        this.customCriticalThreshold = customCriticalThreshold;
+    }
+
+    public String getCustomHighThreshold() {
+        return customHighThreshold;
+    }
+
+    public void setCustomHighThreshold(String customHighThreshold) {
+        this.customHighThreshold = customHighThreshold;
+    }
+
+    public String getCustomMediumThreshold() {
+        return customMediumThreshold;
+    }
+
+    public void setCustomMediumThreshold(String customMediumThreshold) {
+        this.customMediumThreshold = customMediumThreshold;
+    }
+
+    // public boolean getIsCustomizeThresholds() {
+    //     return isCustomizeThresholds;
+    // }
+
+    // public void setCustomizeThresholds(boolean isCustomizeThresholds) {
+    //     this.isCustomizeThresholds = isCustomizeThresholds;
+    // }
 }

--- a/src/main/java/neuvector/NeuVectorTaskConfigurator.java
+++ b/src/main/java/neuvector/NeuVectorTaskConfigurator.java
@@ -37,6 +37,7 @@ public class NeuVectorTaskConfigurator extends AbstractTaskConfigurator {
         config.put("repository", params.getString("repository"));
         config.put("tag", params.getString("tag"));
         config.put("scanLayers", params.getString("scanLayers"));
+        config.put("criticalVul", params.getString("criticalVul"));
         config.put("highVul", params.getString("highVul"));
         config.put("mediumVul", params.getString("mediumVul"));
         if (registryType != null && registryType.equals("custom")) {
@@ -85,6 +86,7 @@ public class NeuVectorTaskConfigurator extends AbstractTaskConfigurator {
         context.put("repository", taskDefinition.getConfiguration().get("repository"));
         context.put("tag", taskDefinition.getConfiguration().get("tag"));
         context.put("scanLayers", taskDefinition.getConfiguration().get("scanLayers"));
+        context.put("criticalVul", taskDefinition.getConfiguration().get("criticalVul"));
         context.put("highVul", taskDefinition.getConfiguration().get("highVul"));
         context.put("mediumVul", taskDefinition.getConfiguration().get("mediumVul"));
         if (registryType != null && registryType.equals("custom")) {

--- a/src/main/java/neuvector/SeverityRating.java
+++ b/src/main/java/neuvector/SeverityRating.java
@@ -1,0 +1,9 @@
+package neuvector;
+
+public enum SeverityRating {
+    None,
+    Low,
+    Medium,
+    High,
+    Critical
+}

--- a/src/main/java/neuvector/report/ScanResult.java
+++ b/src/main/java/neuvector/report/ScanResult.java
@@ -1,6 +1,5 @@
 package neuvector.report;
 
-
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Set;
@@ -19,13 +18,18 @@ public class ScanResult {
     Set<String> existedBlackListVulSet = new HashSet<>();
     Set<String> existedWhiteListVulSet = new HashSet<>();
     boolean isSeverityScaleCustomized;
+    double customizedCriticalSeverityScale;
     double customizedHighSeverityScale;
     double customizedMediumSeverityScale;
-    int highSeverityThreshold;
-    int mediumSeverityThreshold;
+    Double criticalSeverityThreshold = 0.0;
+    Double highSeverityThreshold = 0.0;
+    Double mediumSeverityThreshold = 0.0;
+    int aboveHighSeverityNumber;
+    int criticalSeverityNumber; // total found high severity vuls number
     int highSeverityNumber; // total found high severity vuls number
     int mediumSeverityNumber; // total found medium severity vuls number
     int totalVulnerabilityNumber; // total vuls number
+    Set<Vulnerability> criticalVulnerabilitySet = new HashSet<>();
     Set<Vulnerability> highVulnerabilitySet = new HashSet<>();
     Set<Vulnerability> mediumVulnerabilitySet = new HashSet<>();
     boolean scanLayerConfigured;
@@ -50,6 +54,22 @@ public class ScanResult {
         this.errorMessage = errorMessage;
     }
 
+    public int getAboveHighSeverityNumber() {
+        return aboveHighSeverityNumber;
+    }
+
+    public void setAboveHighSeverityNumber(int aboveHighSeverityNumber) {
+        this.aboveHighSeverityNumber = aboveHighSeverityNumber;
+    }
+
+    public int getCriticalSeverityNumber() {
+        return criticalSeverityNumber;
+    }
+
+    public void setCriticalSeverityNumber(int criticalSeverityNumber) {
+        this.criticalSeverityNumber = criticalSeverityNumber;
+    }
+ 
     public int getHighSeverityNumber() {
         return highSeverityNumber;
     }
@@ -154,6 +174,14 @@ public class ScanResult {
         isSeverityScaleCustomized = severityScaleCustomized;
     }
 
+    public double getCustomizedCriticalSeverityScale() {
+        return customizedCriticalSeverityScale;
+    }
+
+    public void setCustomizedCriticalSeverityScale(double customizedCriticalSeverityScale) {
+        this.customizedCriticalSeverityScale = customizedCriticalSeverityScale;
+    }
+
     public double getCustomizedHighSeverityScale() {
         return customizedHighSeverityScale;
     }
@@ -170,19 +198,27 @@ public class ScanResult {
         this.customizedMediumSeverityScale = customizedMediumSeverityScale;
     }
 
-    public int getHighSeverityThreshold() {
+    public Double getCriticalSeverityThreshold() {
+        return criticalSeverityThreshold;
+    }
+
+    public void setCriticalSeverityThreshold(Double criticalSeverityThreshold) {
+        this.criticalSeverityThreshold = criticalSeverityThreshold;
+    }
+
+    public Double getHighSeverityThreshold() {
         return highSeverityThreshold;
     }
 
-    public void setHighSeverityThreshold(int highSeverityThreshold) {
+    public void setHighSeverityThreshold(Double highSeverityThreshold) {
         this.highSeverityThreshold = highSeverityThreshold;
     }
 
-    public int getMediumSeverityThreshold() {
+    public Double getMediumSeverityThreshold() {
         return mediumSeverityThreshold;
     }
 
-    public void setMediumSeverityThreshold(int mediumSeverityThreshold) {
+    public void setMediumSeverityThreshold(Double mediumSeverityThreshold) {
         this.mediumSeverityThreshold = mediumSeverityThreshold;
     }
 
@@ -192,6 +228,15 @@ public class ScanResult {
 
     public void setTotalVulnerabilityNumber(int totalVulnerabilityNumber) {
         this.totalVulnerabilityNumber = totalVulnerabilityNumber;
+    }
+
+    public Set<Vulnerability> getCriticalVulnerabilitySet() {
+        return criticalVulnerabilitySet;
+    }
+
+    public void setCriticalVulnerabilitySet(Set<Vulnerability> criticalVulnerabilitySet) {
+        this.criticalVulnerabilitySet = criticalVulnerabilitySet;
+
     }
 
     public Set<Vulnerability> getHighVulnerabilitySet() {

--- a/src/main/resources/templates/neuvectorGlobalConfiguration.ftl
+++ b/src/main/resources/templates/neuvectorGlobalConfiguration.ftl
@@ -24,6 +24,12 @@
         [@ww.textfield labelKey="NeuVector Scanner Registry User" name="scannerRegistryUsername" description="Enter the NeuVector Scanner Registry username, if applicable." required="false"/]
         [@ww.password labelKey="NeuVector Scanner Registry Password" name="scannerRegistryPassword" description="Enter the NeuVector Scanner Registry password, if applicable." showPassword="true" required="false"/]
 	[/@ui.bambooSection]
+
+	[@ui.bambooSection titleKey="NeuVector Custom Criteria Configuration"]
+		[@ww.textfield labelKey="Custom Critical Severity Threshold" name="customCriticalThreshold" description="From the Critical Severity Threshold to 10.0 is the Critical Severity Range. Vulnerabilities that score in the Critical Severity Range has the Critical severity level.." required="false"/]
+        [@ww.textfield labelKey="Custom High Severity Threshold" name="customHighThreshold" description="From the High Severity Threshold to Critical Severity Threshold is the High Severity Range. Vulnerabilities that score in the High Severity Range has the High severity level." required="false"/]
+        [@ww.textfield labelKey="Custom Medium Severity Threshold" name="customMediumThreshold" description="From the Medium Severity Threshold to the High Severity Threshold is the Medium Severity Range. Vulnerabilities that score in the Medium Severity Range has the Medium severity level." required="false"/]
+	[/@ui.bambooSection]
 [/@ww.form]
 </body>
 </html>

--- a/src/main/resources/templates/neuvectorScannerTask.ftl
+++ b/src/main/resources/templates/neuvectorScannerTask.ftl
@@ -8,6 +8,7 @@
 [@ww.textfield label="Repository" name="repository" required="true"/]
 [@ww.textfield label="Tag" name="tag" required="true"/]
 [@ww.checkbox label="Scan Layers" name="scanLayers" toggle="true" required="false"/]
+[@ww.textfield label="Critical vulnerabilities to fail" name="criticalVul" required="false"/]
 [@ww.textfield label="High vulnerabilities to fail" name="highVul" required="false"/]
 [@ww.textfield label="Medium vulnerabilities to fail" name="mediumVul" required="false"/>
 


### PR DESCRIPTION
### Summary
1. Add Critical CVE Severity to support CVSS v3 scores 9.0-10.0

### How to verify
update from the previous version, say previous version have 5 High, but in CVSS 3.0 is 4 High 1 Critical
And current threshold for high is 5.
1. if user didn't update the pipeline script => it should hold the previous result, which is fail
2. if user update the pipeline scripts and remain the high is 5, no setting for others => it should pass.